### PR TITLE
Added --importprivkeyfile "import private keys from a file (one key on each line)"

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,7 @@
 Requirements: Python 2.x, with bsddb and twisted packages
 
+Does not work with encrypted wallets yet. 
+
 Usage: pywallet.py [options]
 
 Options:
@@ -7,6 +9,8 @@ Options:
   -h, --help            show this help message and exit
   --dumpwallet          dump wallet in json format
   --importprivkey=KEY   import private key from vanitygen
+  --importprivkeyfile=PRIVKEYFILE
+                        import private keys from a file (one key on each line)
   --importhex           KEY is in hexadecimal format
   --datadir=DATADIR     wallet directory (defaults to bitcoin default)
   --wallet=WALLETFILE   wallet filename (defaults to wallet.dat)
@@ -16,17 +20,22 @@ Options:
   --otherversion=OTHERVERSION
                         use other network address type, whose version is
                         OTHERVERSION
-  --info                display pubkey, privkey (both depending on the
-                        network) and hexkey
-  --reserve             import as a reserve key, i.e. it won't show in the
-                        adress book
+  --info                display pubkey, privkey (both depending on the network) and
+                        hexkey
+  --reserve             import as a reserve key, i.e. it won't show in the adress
+                        book
   --balance=KEY_BALANCE
                         prints balance of KEY_BALANCE
   --web                 run pywallet web interface
   --port=PORT           port of web interface (defaults to 8989)
-
-
-
+  --recover             recover your deleted keys, use with recov_size and
+                        recov_device
+  --recov_device=RECOV_DEVICE
+                        device to read (e.g. /dev/sda1)
+  --recov_size=RECOV_SIZE
+                        number of bytes to read (e.g. 20Mo or 50Gio)
+  --recov_outputdir=RECOV_OUTPUTDIR
+                        output directory where the recovered wallet will be put
 
 
 

--- a/pywallet.py
+++ b/pywallet.py
@@ -51,7 +51,7 @@ from datetime import datetime
 from subprocess import *
 
 
-max_version = 41000
+max_version = 61000
 addrtype = 0
 json_db = {}
 private_keys = []

--- a/pywallet.py
+++ b/pywallet.py
@@ -1202,7 +1202,6 @@ def read_wallet(json_db, db_env, walletfile, print_wallet, print_wallet_transact
 
 
 def importprivkey(db, sec, label, reserve, keyishex):
-	print sec
 	if keyishex is None:
 		pkey = regenerate_key(sec)
 	elif len(sec) == 64:
@@ -2009,10 +2008,6 @@ if __name__ == '__main__':
 		print json.dumps(json_db, sort_keys=True, indent=4)
 		exit(0)
 
-	if json_db['version'] > max_version:
-		print "Version mismatch (must be <= %d)" % max_version
-		exit(0)
-
 	if options.key:
 		options.keys = [key]
 		
@@ -2021,6 +2016,9 @@ if __name__ == '__main__':
 		options.keys = open(options.privkeyfile, "r").read().splitlines();
 	
 	if options.keys is not None and type(options.keys)==list and len(options.keys) > 0:
+		if json_db['version'] > max_version:
+			print "Version mismatch (must be <= %d)" % max_version
+			exit(0)
 		db = open_wallet(db_env, determine_db_name(), writable=True)
 		for key in options.keys: 
 			if (options.keyishex is None and key in private_keys) or (options.keyishex is not None and key in private_hex_keys):


### PR DESCRIPTION
This is useful if you want to take a generated set of pub/priv keypairs and import all the privs into your wallet, and upload all of the pubs to a server running a merchant site. 

I also increased the maxversion to 0.4.1 and it seems to work fine (but not likely to work on encrypted wallets). 

Tidied up the if..elseif..else stuff in the options parser. Things either match, process, and exit or they just move on to the next conditional. 