### PR TITLE
Allow bsddb3 for compatibility with Gentoo

### DIFF
--- a/pywallet.py
+++ b/pywallet.py
@@ -19,7 +19,10 @@ missing_dep = []
 try:
 	from bsddb.db import *
 except:
-	missing_dep.append('bsddb')
+	try:
+		from bsddb3.db import *
+	except:
+		missing_dep.append('bsddb')
 
 import os, sys, time, re
 pyw_filename = os.path.basename(__file__)


### PR DESCRIPTION
Fix bsddb incompatibility with Gentoo

It is the same library, but unfortunately Gentoo renamed bsddb to bsddb3 when packaging it.
If bsddb is not found, try importing bsddb3 instead, before reporting error.
This works, to make pywallet successfully run on Gentoo.
