### PR TITLE
Fixed litecoin prefix

### DIFF
--- a/pywallet.py
+++ b/pywallet.py
@@ -1227,8 +1227,6 @@ def PrivKeyToSecret(privkey):
 
 def SecretToASecret(secret, compressed=False):
 	prefix = chr((addrtype+128)&255)
-	if addrtype==48:  #assuming Litecoin
-		prefix = chr(176)
 	vchIn = prefix + secret
 	if compressed: vchIn += '\01'
 	return EncodeBase58Check(vchIn)


### PR DESCRIPTION
Litecoin private keys were showing wrong in the dump, this fixes it.

Litecoin wallets recover still won't work as expected, but, with this fix pywallet can be used to recover and then dump the keys, using --otherversion 48, and it will show correctly the private keys which can be then imported into litecoind.
