### PR TITLE
Adding a backup API endpoint for balance checking 

### DIFF
--- a/pywallet.py
+++ b/pywallet.py
@@ -122,6 +122,8 @@ passphrase = ""
 global_merging_message = ["",""]
 
 balance_site = 'https://blockchain.info/q/addressbalance/'
+backup_balance_site ='https://api.blockcypher.com/v1/btc/main/addrs/'
+
 aversions = {}
 for i in range(256):
 	aversions[i] = "version %d" % i;
@@ -2933,7 +2935,12 @@ def importprivkey(db, sec, label, reserve, verbose=True):
 
 def balance(site, address):
 	page=urllib.urlopen("%s%s" % (site, address))
-	return page.read()
+	query_result=page.read()
+	#If the initial API call returned an error, use a secondary API
+	if query_result.startswith("error"):
+		page = urllib.urlopen("%s%s" % (backup_balance_site, address))
+		query_result = json.loads(page.read())["balance"]
+	return query_result
 
 def read_jsonfile(filename):
 	filin = open(filename, 'r')


### PR DESCRIPTION
Issue
==============
While recovering a wallet with a large amount of addresses (>100) I kept running into issues with the API which is supposed to provide the balance of the address, as the API rate limits heavily. This meant that after 10 addresses or so, the balance field in the JSON file would only contain "error code: 1015". The issue was brought up earlier by another user in issue 33: https://github.com/jackjack-jj/pywallet/issues/33

Solution
==============
I implemented the fix suggested in the issue, and it solved the problem with obtaining the balance. 
Specifically if the original API returns an error, the script reaches out to the "backup" API endpoint which has far more permissive rate limits. The "backup" API is provided by BlockCypher and only the address is shared with them. 

Notes
==============
A potential solution would be to wait between requests but that would significantly impact the execution time of the script.